### PR TITLE
chore: add warning that safari (version < 26) doesn't support svg as …

### DIFF
--- a/application/cfg.go
+++ b/application/cfg.go
@@ -249,6 +249,9 @@ func (c *Configurator) OnDestroy(f func()) {
 	c.destructors = append(c.destructors, f)
 }
 
+// AppIcon sets the icon of the application
+//
+// Warning: Safari currently (version < 26) doesn't support .svg files
 func (c *Configurator) AppIcon(ico core.URI) *core.Application {
 	c.appIconUri = proto.URI(ico)
 	return c.app


### PR DESCRIPTION
This just adds a small warning that the current version (and older) of safari don't support .svg files as favicons.