### PR TITLE
fix(form): do not write metadata-only underscore fields

### DIFF
--- a/presentation/ui/form/group.go
+++ b/presentation/ui/form/group.go
@@ -39,7 +39,7 @@ func GroupsFor[T any]() []Group {
 // GroupsOf returns field groups for the given struct type.
 // It groups fields by their "section" tag, skipping fields when:
 // - tag `visible:"false"` is set
-// - the field is unexported and does not start with "_" (private)
+// - the field is unexported, unless it starts with "_" and has a label tag
 // - the field name appears in ignoreFields
 func GroupsOf(p reflect.Type, ignoreFields ...string) []Group {
 	var res []Group
@@ -58,7 +58,11 @@ func GroupsOf(p reflect.Type, ignoreFields ...string) []Group {
 			continue
 		}
 
-		if !strings.HasPrefix(field.Name, "_") && !field.IsExported() {
+		if strings.HasPrefix(field.Name, "_") {
+			if _, ok := field.Tag.Lookup("label"); !ok {
+				continue
+			}
+		} else if !field.IsExported() {
 			continue
 		}
 


### PR DESCRIPTION
Problem: form.Auto treated blank identifier fields as editable form fields when they used a settable type like string. Credential templates such as DNSApiToken store metadata on an unexported _ field with credentialName, credentialDescription, and credentialLogo tags; rendering that field as a text input caused reflect.Value.Set to panic because blank identifier fields are not assignable.

Solution: GroupsOf now keeps underscore-prefixed fields only when they carry a label tag, preserving existing label and separator marker fields while excluding metadata-only fields from form rendering. This keeps credential metadata readable via FieldByName("_") for secret creation/edit UI, but prevents RenderText from binding it as editable state.