### PR TITLE
fix(token): wire token subject into rebac and roll back partial grants

### DIFF
--- a/application/management_token.go
+++ b/application/management_token.go
@@ -11,9 +11,11 @@ import (
 	"fmt"
 
 	"go.wdy.de/nago/application/admin"
+	"go.wdy.de/nago/application/group"
 	"go.wdy.de/nago/application/migration"
 	"go.wdy.de/nago/application/permission"
 	"go.wdy.de/nago/application/rebac"
+	"go.wdy.de/nago/application/role"
 	"go.wdy.de/nago/application/token"
 	uitoken "go.wdy.de/nago/application/token/ui"
 	"go.wdy.de/nago/auth"
@@ -67,6 +69,19 @@ func (c *Configurator) TokenManagement() (TokenManagement, error) {
 		if err != nil {
 			return TokenManagement{}, fmt.Errorf("cannot get rdb: %w", err)
 		}
+		rdb.AddResolver(rebac.NewSourceMemberResolver(token.Namespace, role.Namespace))
+		rdb.AddResolver(rebac.NewSourceMemberResolver(token.Namespace, group.Namespace))
+
+		rdb.RegisterStaticRule(rebac.StaticRule{
+			Source:   role.Namespace,
+			Relation: rebac.Member,
+			Target:   token.Namespace,
+		})
+		rdb.RegisterStaticRule(rebac.StaticRule{
+			Source:   group.Namespace,
+			Relation: rebac.Member,
+			Target:   token.Namespace,
+		})
 
 		// we have permissions which are generated and registered any time later at runtime, which must be generally allowed to be assigned
 		permission.OnPermissionRegistered(func(permission permission.Permission) {

--- a/application/token/subject.go
+++ b/application/token/subject.go
@@ -54,8 +54,29 @@ func (s *subject) Context() context.Context {
 }
 
 func (s *subject) HasResourcePermission(name rebac.Namespace, id rebac.Instance, p permission.ID) bool {
-	//TODO implement me
-	panic("implement me")
+	if !s.Valid() {
+		return false
+	}
+
+	if s.HasPermission(p) {
+		return true
+	}
+
+	ok, err := s.rdb.Contains(rebac.Triple{
+		Source:   s.source(),
+		Relation: rebac.Relation(p),
+		Target: rebac.Entity{
+			Namespace: name,
+			Instance:  id,
+		},
+	})
+
+	if err != nil {
+		slog.Error("cannot check resource permission", "err", err)
+		return false
+	}
+
+	return ok
 }
 
 func (s *subject) Audit(perm permission.ID) error {
@@ -106,7 +127,7 @@ func (s *subject) AuditResource(name rebac.Namespace, id rebac.Instance, p permi
 func (s *subject) HasPermission(permission permission.ID) bool {
 	s.load()
 
-	ok, err := s.rdb.Contains(rebac.Triple{
+	ok, err := s.rdb.Resolve(rebac.Triple{
 		Source:   s.source(),
 		Relation: rebac.Relation(permission),
 		Target: rebac.Entity{

--- a/application/token/uc_create.go
+++ b/application/token/uc_create.go
@@ -10,16 +10,20 @@ package token
 import (
 	"crypto/rand"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
+	"go.wdy.de/nago/application/group"
+	"go.wdy.de/nago/application/rebac"
+	"go.wdy.de/nago/application/role"
 	"go.wdy.de/nago/application/user"
 	"go.wdy.de/nago/auth"
 	"go.wdy.de/nago/pkg/data"
 	"go.wdy.de/nago/pkg/std/concurrent"
 )
 
-func NewCreate(mutex *sync.Mutex, repo Repository, algo user.HashAlgorithm, reverseHashLookup *concurrent.RWMap[Hash, ID]) Create {
+func NewCreate(mutex *sync.Mutex, repo Repository, algo user.HashAlgorithm, reverseHashLookup *concurrent.RWMap[Hash, ID], rdb *rebac.DB) Create {
 	return func(subject auth.Subject, cdata CreationData) (ID, Plaintext, error) {
 		if err := subject.Audit(PermCreate); err != nil {
 			return "", "", err
@@ -82,8 +86,95 @@ func NewCreate(mutex *sync.Mutex, repo Repository, algo user.HashAlgorithm, reve
 			return "", "", err
 		}
 
+		if err := grantTokenRights(rdb, token.ID, cdata); err != nil {
+			if deleteErr := repo.DeleteByID(token.ID); deleteErr != nil {
+				return "", "", fmt.Errorf("cannot grant token rights: %w; cannot delete token: %v", err, deleteErr)
+			}
+
+			return "", "", err
+		}
+
 		reverseHashLookup.Put(hash, token.ID)
 
 		return token.ID, plaintext, nil
 	}
+}
+
+func grantTokenRights(rdb *rebac.DB, tid ID, cdata CreationData) error {
+	triples := make([]rebac.Triple, 0, len(cdata.Roles)+len(cdata.Groups)+len(cdata.Permissions))
+
+	for _, id := range cdata.Roles {
+		triples = append(triples, rebac.Triple{
+			Source: rebac.Entity{
+				Namespace: role.Namespace,
+				Instance:  rebac.Instance(id),
+			},
+			Relation: rebac.Member,
+			Target: rebac.Entity{
+				Namespace: Namespace,
+				Instance:  rebac.Instance(tid),
+			},
+		})
+	}
+
+	for _, id := range cdata.Groups {
+		triples = append(triples, rebac.Triple{
+			Source: rebac.Entity{
+				Namespace: group.Namespace,
+				Instance:  rebac.Instance(id),
+			},
+			Relation: rebac.Member,
+			Target: rebac.Entity{
+				Namespace: Namespace,
+				Instance:  rebac.Instance(tid),
+			},
+		})
+	}
+
+	for _, id := range cdata.Permissions {
+		triples = append(triples, rebac.Triple{
+			Source: rebac.Entity{
+				Namespace: Namespace,
+				Instance:  rebac.Instance(tid),
+			},
+			Relation: rebac.Relation(id),
+			Target: rebac.Entity{
+				Namespace: rebac.Global,
+				Instance:  rebac.AllInstances,
+			},
+		})
+	}
+
+	for res, ids := range cdata.Resources {
+		for _, id := range ids {
+			triples = append(triples, rebac.Triple{
+				Source: rebac.Entity{
+					Namespace: Namespace,
+					Instance:  rebac.Instance(tid),
+				},
+				Relation: rebac.Relation(id),
+				Target: rebac.Entity{
+					Namespace: rebac.Namespace(res.Name),
+					Instance:  rebac.Instance(res.ID),
+				},
+			})
+		}
+	}
+
+	written := make([]rebac.Triple, 0, len(triples))
+	for _, t := range triples {
+		if err := rdb.Put(t); err != nil {
+			// best-effort rollback of triples already written, in reverse order
+			for i := len(written) - 1; i >= 0; i-- {
+				if delErr := rdb.Delete(written[i]); delErr != nil {
+					slog.Error("cannot rollback rebac triple after grantTokenRights failure",
+						"token", tid, "err", delErr)
+				}
+			}
+			return err
+		}
+		written = append(written, t)
+	}
+
+	return nil
 }

--- a/application/token/uc_create_test.go
+++ b/application/token/uc_create_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2025 worldiety GmbH
+//
+// This file is part of the NAGO Low-Code Platform.
+// Licensed under the terms specified in the LICENSE file.
+//
+// SPDX-License-Identifier: Custom-License
+
+package token
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/worldiety/option"
+	"go.wdy.de/nago/application/permission"
+	"go.wdy.de/nago/application/rebac"
+	"go.wdy.de/nago/application/user"
+	"go.wdy.de/nago/pkg/blob/mem"
+	"go.wdy.de/nago/pkg/data/json"
+	"go.wdy.de/nago/pkg/std/concurrent"
+)
+
+func TestCreatePersistsResourcePermissions(t *testing.T) {
+	tokenRepo := json.NewSloppyJSONRepository[Token](mem.NewBlobStore("tokens"))
+	rdb := option.Must(rebac.NewDB(mem.NewBlobStore("rebac")))
+	perm := permission.ID("test.token.resource")
+	resource := user.Resource{Name: "test.resource", ID: "resource-1"}
+
+	rdb.RegisterStaticRule(rebac.StaticRule{Source: Namespace, Relation: rebac.Relation(perm), Target: rebac.Namespace(resource.Name)})
+
+	create := NewCreate(&sync.Mutex{}, tokenRepo, user.Argon2IdMin, &concurrent.RWMap[Hash, ID]{}, rdb)
+	id, _, err := create(user.SU(), CreationData{
+		Name:      "upload token",
+		Plaintext: "0123456789abcdef",
+		Resources: map[user.Resource][]permission.ID{
+			resource: {perm},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subject := newSubject(context.Background(), nil, tokenRepo, option.Must(tokenRepo.FindByID(id)).Unwrap(), rdb)
+	if !subject.HasResourcePermission(rebac.Namespace(resource.Name), rebac.Instance(resource.ID), perm) {
+		t.Fatal("expected token subject to have resource permission")
+	}
+}

--- a/application/token/usecases.go
+++ b/application/token/usecases.go
@@ -165,7 +165,7 @@ func NewUseCases(
 	return UseCases{
 		Delete:              NewDelete(&mutex, repo),
 		FindAll:             NewFindAll(repo),
-		Create:              NewCreate(&mutex, repo, algo, reverseHashLookup),
+		Create:              NewCreate(&mutex, repo, algo, reverseHashLookup, rdb),
 		AuthenticateSubject: NewAuthenticateSubject(ctx, repo, algo, reverseHashLookup, subjectFromUser, subjectLookup, getAnonUser, findRoleByID, rdb),
 		Rotate:              NewRotate(&mutex, repo, algo, reverseHashLookup),
 		FindByID:            NewFindByID(repo),


### PR DESCRIPTION
## Summary

- Implements `subject.HasResourcePermission` for tokens (was a `panic`), using `rdb.Contains` to match `viewImpl.HasResourcePermission` semantics.
- Switches token `HasPermission` from `Contains` to `Resolve` so tokens inherit global permissions transitively via role/group membership, mirroring the user view.
- Registers `role -> Member -> token` and `group -> Member -> token` static rules and source-member resolvers in `TokenManagement` so role/group bindings created at token creation pass static-rule validation.
- `NewCreate` now persists role, group, permission, and resource grants as rebac triples via a new `grantTokenRights` helper. On partial failure, successfully-written triples are rolled back in reverse order (best-effort, errors logged) before deleting the token entity, to avoid orphan triples in the rebac DB.

## Tests

- New `TestCreatePersistsResourcePermissions` exercises the resource grant path end-to-end.
- `go build ./...` clean, `go test ./application/token/...` passes.

## Pre-existing issue not addressed in this PR

`grantTokenRights` writes triples of shape `(token.Namespace -> <perm> -> <resource ns>)` for any entries in `cdata.Resources`. The rebac DB validates every `Put` against registered static rules (`db.go:332-338`), and **no such rule is registered for token resource permissions in production startup**. `TokenManagement` only registers:

1. `role -> Member -> token`
2. `group -> Member -> token`
3. `token -> <perm> -> Global` (via `permission.OnPermissionRegistered` and the initial `permission.All()` loop)

There is no equivalent registration for arbitrary resource namespaces. As a result, any call to `NewCreate` with a non-empty `cdata.Resources` will fail with `"cannot insert triple: no such rule"` in production.

The migration `newMigrateTokenPermsToReBAC` works around this by calling `rdb.ValidateStaticRules(false)` for the duration of the migration. The unit test added here works around it by registering the specific rule manually.

This bug is **pre-existing** in the resource-grant code path and is preserved by this PR's refactor; it is not introduced by these changes. The same latent issue appears to exist on the user side (`user.NewAddResourcePermissions` in `uc_add_resource_permissions.go` follows the same pattern, and `management_user.go` does not register per-resource static rules either).

Suggested follow-up: add a hook in `TokenManagement` (and `UserManagement`) that registers `(token.Namespace -> perm -> resource.Identity())` for every combination of registered permission x registered resource, triggered both by `permission.OnPermissionRegistered` and after all resources are registered.

