### PR TITLE
fix: svg favicons do not work in most browsers

### DIFF
--- a/application/cfg.go
+++ b/application/cfg.go
@@ -296,7 +296,7 @@ func (c *Configurator) GetNoFooter() []core.NavigationPath {
 
 // AppIcon sets the icon of the application
 //
-// Warning: Safari currently (version < 26) doesn't support .svg files
+// Warning: Older Safari versions (< 26) don't support .svg files
 func (c *Configurator) AppIcon(ico core.URI) *core.Application {
 	c.appIconUri = proto.URI(ico)
 	return c.app

--- a/application/cfg_page.go
+++ b/application/cfg_page.go
@@ -270,6 +270,18 @@ func (c *Configurator) newHandler() http.Handler {
 
 	}))
 
+	// Serve the configured application icon under the static favicon paths referenced by index.html.
+	faviconHandler := http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if c.appIconUri == "" {
+			http.NotFound(writer, request)
+			return
+		}
+
+		http.Redirect(writer, request, string(c.appIconUri), http.StatusFound)
+	})
+	r.Mount("/favicon.svg", faviconHandler)
+	r.Mount("/favicon.ico", faviconHandler)
+
 	if len(c.fsys) > 0 {
 		c.defaultLogger().Info("serving fsys assets")
 		assets := statigz.FileServer(mergefs.Merge(c.fsys...).(mergefs.MergedFS), statigz.EncodeOnInit)

--- a/pkg/magic/magic.go
+++ b/pkg/magic/magic.go
@@ -9,9 +9,10 @@ package magic
 
 import (
 	"bytes"
-	"go.wdy.de/nago/pkg/blob/crypto"
 	"net/http"
 	"unicode"
+
+	"go.wdy.de/nago/pkg/blob/crypto"
 )
 
 var zipMagicBytes = [][]byte{
@@ -42,6 +43,10 @@ func Detect(buf []byte) string {
 
 	if maybeJson(buf) {
 		return "application/json"
+	}
+
+	if maybeSVG(buf) {
+		return "image/svg+xml"
 	}
 
 	return http.DetectContentType(buf)
@@ -76,4 +81,53 @@ func maybeJson(buf []byte) bool {
 	}
 
 	return false
+}
+
+func maybeSVG(buf []byte) bool {
+	// skip a possible UTF-8 BOM
+	buf = bytes.TrimPrefix(buf, []byte{0xEF, 0xBB, 0xBF})
+
+	// only inspect the beginning of the document to keep detection cheap
+	const window = 1024
+	if len(buf) > window {
+		buf = buf[:window]
+	}
+
+	for {
+		buf = bytes.TrimLeftFunc(buf, unicode.IsSpace)
+		if len(buf) == 0 || buf[0] != '<' {
+			return false
+		}
+
+		// Skip xml declaration, comments, doctype or other markup declarations
+		// Only look for elements with <svg* as root
+		switch {
+		case bytes.HasPrefix(buf, []byte("<?")):
+			end := bytes.Index(buf, []byte("?>"))
+			if end < 0 {
+				return false
+			}
+			buf = buf[end+2:]
+
+		case bytes.HasPrefix(buf, []byte("<!--")):
+			end := bytes.Index(buf[4:], []byte("-->"))
+			if end < 0 {
+				return false
+			}
+			buf = buf[4+end+3:]
+
+		case bytes.HasPrefix(buf, []byte("<!")):
+			end := bytes.IndexByte(buf, '>')
+			if end < 0 {
+				return false
+			}
+			buf = buf[end+1:]
+
+		default:
+			lower := bytes.ToLower(buf)
+			return bytes.HasPrefix(lower, []byte("<svg>")) || bytes.HasPrefix(lower, []byte("<svg ")) ||
+				bytes.HasPrefix(lower, []byte("<svg/")) || bytes.HasPrefix(lower, []byte("<svg\t")) ||
+				bytes.HasPrefix(lower, []byte("<svg\n")) || bytes.HasPrefix(lower, []byte("<svg\r"))
+		}
+	}
 }


### PR DESCRIPTION
Two main changes (_+ on minor_):

1. pkg/magic/magic.go: Detects possible svgs to return them with the type image/svg+xml (instead of text/xml like previously)
2. application/cfg_page.go: Add favicon handler to serve app icon under static favicon paths (referenced in index.html)
3. _application/cfg.go: Adjust safari svg favicon support hint_