### PR TITLE
fix(navsplitview): WithDetail sets detailWidth instead of sidebarWidth

### DIFF
--- a/presentation/ui/navsplitview/threecolumn.go
+++ b/presentation/ui/navsplitview/threecolumn.go
@@ -15,7 +15,7 @@ import (
 	"go.wdy.de/nago/presentation/ui/alert"
 )
 
-// TThreeColumn is a layout component (TwoColumn).
+// TThreeColumn is a layout component (ThreeColumn).
 type TThreeColumn struct {
 	nav              Factory
 	frame            ui.Frame
@@ -77,8 +77,9 @@ func (c TThreeColumn) WidthSidebar(width ui.Length) TThreeColumn {
 	c.sidebarWidth = width
 	return c
 }
+
 func (c TThreeColumn) WidthDetail(width ui.Length) TThreeColumn {
-	c.sidebarWidth = width
+	c.detailWidth = width
 	return c
 }
 
@@ -155,12 +156,9 @@ func (c TThreeColumn) Render(ctx core.RenderContext) core.RenderNode {
 
 	// smartphone etc
 	if wnd.Info().SizeClass <= core.SizeClassMedium {
-		if detailView == nil {
-			return ui.VStack().Render(ctx)
-		}
-
 		var myView core.View
 		var backAction func()
+
 		switch {
 		case detailId != "":
 			myView = detailView

--- a/presentation/ui/navsplitview/twocolumn.go
+++ b/presentation/ui/navsplitview/twocolumn.go
@@ -146,10 +146,6 @@ func (c TTwoColumn) Render(ctx core.RenderContext) core.RenderNode {
 	}
 
 	if wnd.Info().SizeClass <= core.SizeClassMedium {
-		if detailView == nil {
-			return ui.VStack().Render(ctx)
-		}
-
 		return ui.VStack(
 			ui.If(detailId != "", ui.SecondaryButton(func() {
 				wnd.Navigation().BackwardTo(wnd.Path(), wnd.Values().Delete(detailKey))


### PR DESCRIPTION
- Remove unreachable code in the render function of TwoColumn and ThreeColumn.
- Change doc comment of TThreeColumn