### PR TITLE
fix(CountDown): clamp negative CountDown duration to zero

### DIFF
--- a/presentation/ui/countdown.go
+++ b/presentation/ui/countdown.go
@@ -45,7 +45,17 @@ type TCountDown struct {
 
 // CountDown creates a new countdown timer initialized with the given duration.
 // By default, days, hours, minutes, and seconds are all displayed.
+// A negative duration is clamped to zero.
 func CountDown(duration time.Duration) TCountDown {
+	// Negative values must never reach Render/proto.DurationSec: the
+	// float64->uint64 conversion there is implementation-specific for
+	// negative input and has been observed to corrupt the binary wire
+	// protocol ("varint too long"), breaking the client for the rest
+	// of the session.
+	if duration < 0 {
+		duration = 0
+	}
+
 	return TCountDown{
 		duration:    duration,
 		showDays:    true,


### PR DESCRIPTION
CountDown() accepted arbitrary time.Duration values, including negative ones (a common case: counting down to a deadline that already passed). Render() converts the duration via proto.DurationSec(c.duration.Seconds()), a float64-to-uint64 cast. For negative input this conversion is implementation-specific per the Go spec and has been observed on linux/amd64 to produce a bit pattern that corrupts the binary WebSocket wire protocol ("varint too long"), breaking the client's event stream for the rest of the session.